### PR TITLE
Mac address validation

### DIFF
--- a/libs/common.py
+++ b/libs/common.py
@@ -173,7 +173,7 @@ def get_attr(user):
     for att in atts:
         if att in user.keys():
             att_compilation[att] = user.get(att)
-        elif att:
+        else:
             att_compilation[att] = ['0']
     return att_compilation
 

--- a/libs/common.py
+++ b/libs/common.py
@@ -173,6 +173,6 @@ def get_attr(user):
     for att in atts:
         if att in user.keys():
             att_compilation[att] = user.get(att)
-        else:
-            att_compilation[att] = []
+        elif att:
+            att_compilation[att] = ['0']
     return att_compilation

--- a/libs/common.py
+++ b/libs/common.py
@@ -176,3 +176,12 @@ def get_attr(user):
         elif att:
             att_compilation[att] = ['0']
     return att_compilation
+
+def get_valid_macs(macs : list):
+    fixed = []
+    for mac in macs:
+        if re.match("[0-9a-f]{2}([-:]?)[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$", mac.lower()):
+            fixed.append(mac.replace(":", "-").upper())
+        else:
+            flash(f"Invalid MAC address: {mac}", "error")
+    return fixed

--- a/static/css/components/flash_messages.css
+++ b/static/css/components/flash_messages.css
@@ -11,6 +11,7 @@
     font-weight: bold;
     text-shadow: 0 -1px 0 rgba(77, 77, 77, 0.5);
     color: #FFF;
+    overflow-wrap: break-word;
 }
 #flash-messages li:first-child {
     margin-top: 10px;


### PR DESCRIPTION
#### feat
MAC addresses will be saved with uppercase format, and with '-' as separator.
User can write them with lowecase or uppercase, and with ':' or '-'(but not both at once), and the mac will still be saved with uppercase and -.
Only valid MAC addresses will be saved, and invalid macs will be flashed
#### fixes
- bigger flashed messages were overflowing the message box
- no longer saving '0' directly into the ldap database when array fields(like phones, other mail and macs) are saved empty